### PR TITLE
fix[pagination-fix]: Handle empty tables and improve pagination edge …

### DIFF
--- a/lib/components/TableParts/TablePagination.tsx
+++ b/lib/components/TableParts/TablePagination.tsx
@@ -47,7 +47,7 @@ export const TablePagination = (props: TablePaginationProps) => {
           className="AGT-one-line-text"
           color="secondary"
         >
-          {page * pageSize + 1} - {Math.min(page * pageSize + pageSize, rowCount)} of {rowCount}
+          {rowCount > 0 ? page * pageSize + 1 : 0} - {Math.min(page * pageSize + pageSize, rowCount)} of {rowCount}
         </ComponentOverride>
         <ComponentOverride
           defaultComponent={IconButton}
@@ -61,7 +61,7 @@ export const TablePagination = (props: TablePaginationProps) => {
           defaultComponent={IconButton}
           overrideComponent={customComponents?.iconButton}
           onClick={() => setPage(page + 1)}
-          disabled={page === Math.ceil(rowCount / pageSize) - 1}
+          disabled={page === Math.max(0, Math.ceil(rowCount / pageSize) - 1)}
           icon={<ArrowRightPageIcon />}
           iconType={IconButtonType.ArrowRight}
         />

--- a/lib/styles/defaults.css
+++ b/lib/styles/defaults.css
@@ -52,8 +52,8 @@
   --AGT-resize-bar-color: var(--AGT-c-active);
   --AGT-resize-bar-background: linear-gradient(
     90deg,
-    #0000 calc(var(--hover-size) / 2 - 1px),
-    var(--AGT-c-resize-bar) 0 calc(var(--hover-size) / 2 + 1px),
+    #0000 calc(var(--AGT-resize-bar-hover-size) / 2 - 1px),
+    var(--AGT-c-resize-bar) 0 calc(var(--AGT-resize-bar-hover-size) / 2 + 1px),
     #0000 0 100%
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sanbira/atom-grid-table",
   "private": false,
-  "version": "1.0.28",
+  "version": "1.0.29",
   "license": "MIT",
   "type": "module",
   "repository": {


### PR DESCRIPTION
…cases

- Fix pagination display to show "0" instead of "1" for empty tables
- Update next page button to handle edge case with Math.max for empty rowCount
- Fix CSS variable reference from --hover-size to --AGT-resize-bar-hover-size
- Bump version to 1.0.29